### PR TITLE
add_index_page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,5 @@
 @import "reset";
 @import "font-awesome-sprockets";
 @import "font-awesome";
-@import "index";
+@import "top_index";
+@import "posts_index";

--- a/app/assets/stylesheets/posts_index.scss
+++ b/app/assets/stylesheets/posts_index.scss
@@ -2,10 +2,11 @@
   // width: 1300px;
   .posts {
     // postを3つまで横並びにする
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
+    // display: grid;
+    // grid-template-columns: 1fr 1fr 1fr;
     // gap: 20px;
-    // display: flex;
+    display: flex;
+    flex-wrap: wrap;
     // flexboxのオプション どういう風に横並びにするかを指定
     justify-content: center;
     width: 100%;

--- a/app/assets/stylesheets/posts_index.scss
+++ b/app/assets/stylesheets/posts_index.scss
@@ -1,0 +1,94 @@
+.index_wrapper {
+  // width: 1300px;
+  .posts {
+    // postを3つまで横並びにする
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    // gap: 20px;
+    // display: flex;
+    // flexboxのオプション どういう風に横並びにするかを指定
+    justify-content: center;
+    width: 100%;
+    // max-width: 1300px;
+    // padding-right: 15px;
+    // padding-left: 15px;
+    // margin-right: 15px;
+    // margin-left: 15px;
+    .post {
+      border: solid 1px gray;
+      // display: flex;
+      height: 650px;
+      width: 360px;
+      // position: absolute;
+      margin: 15px;
+      // 改行後の文字列のスタートを一番上に
+      text-align: start;
+      &__top {
+        width: 100%;
+        // display: flex;
+        &__user {
+          display: flex;
+          .icon {
+            width: 45px;
+            height: 45px;
+            margin-right: 10px;
+          }
+          a {
+            line-height: 45px;
+            text-decoration: none;
+            color: #7b777c;
+            // padding-top: 5px;
+          }
+        }
+      }
+      &__center {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 25px;
+        height: 50%;
+        width: 100%;
+        // flex-direction: column;
+        // justify-content: space-around;
+        .image {
+          display: block;
+          width: 200px;
+          height: 100%;
+          background-color: red;
+          margin-left: 25px;
+        }
+        &__content {
+          width: 50px;
+          writing-mode: vertical-rl;
+          font-size: 1.25rem;
+          line-height: 1.2;
+          margin-right: 25px;
+        }
+      }
+      &__bottom {
+        // display: flex;
+        height: 250px;
+        // width: auto;
+        // text-align: right;
+        width: 100%;
+        writing-mode: vertical-rl;
+        margin-bottom: -30px;
+        &__title {
+          font-size: 17px;
+          text-indent: 1em;
+          margin-right: 20px;
+        }
+        &__author {
+          text-align: end;
+          padding: 5px;
+          margin-right: 10px;
+        }
+        &__content {
+          font-size: 15px;
+          line-height: 2.0;
+          // text-overflow: ellipsis;
+          margin-right: 10px;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/top_index.scss
+++ b/app/assets/stylesheets/top_index.scss
@@ -38,8 +38,6 @@
   .main {
     text-align: center;
     margin-top: 10%;
-    h2 {
-    }
     p {
       font-size: 1.125rem;
       margin: 10px 0 42px;

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -68,3 +68,20 @@
           著者: 伊藤駿介
         %p.post__bottom__content
           この作品ではタコが人間になるまでの過程を描いているため、今後はイカを積極的に食べていこうと思える作品です。
+    .post
+      .post__top
+        .post__top__user
+          %img.icon(src="" alt="")/
+          = link_to "" do
+            ユーザ名
+      .post__center
+        %img.image(src="" alt="")/
+        %h5.post__center__content
+          なぜ家庭にあるのが"イカ焼き器"ではなく"たこ焼き器"なのか
+      .post__bottom
+        %p.post__bottom__title
+          『壺からの脱出』
+        %p.post__bottom__author
+          著者: 伊藤駿介
+        %p.post__bottom__content
+          この作品ではタコが人間になるまでの過程を描いているため、今後はイカを積極的に食べていこうと思える作品です。

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -1,0 +1,70 @@
+.index_wrapper
+  .posts
+    .post
+      .post__top
+        .post__top__user
+          %img.icon(src="" alt="")/
+          = link_to "" do
+            ユーザ名
+      .post__center
+        %img.image(src="" alt="")/
+        %h5.post__center__content
+          なぜ家庭にあるのが"イカ焼き器"ではなく"たこ焼き器"なのか
+      .post__bottom
+        %p.post__bottom__title
+          『壺からの脱出』
+        %p.post__bottom__author
+          著者: 伊藤駿介
+        %p.post__bottom__content
+          この作品ではタコが人間になるまでの過程を描いているため、今後はイカを積極的に食べていこうと思える作品です。
+    .post
+      .post__top
+        .post__top__user
+          %img.icon(src="" alt="")/
+          = link_to "" do
+            ユーザ名
+      .post__center
+        %img.image(src="" alt="")/
+        %h5.post__center__content
+          なぜ家庭にあるのが"イカ焼き器"ではなく"たこ焼き器"なのか
+      .post__bottom
+        %p.post__bottom__title
+          『壺からの脱出』
+        %p.post__bottom__author
+          著者: 伊藤駿介
+        %p.post__bottom__content
+          この作品ではタコが人間になるまでの過程を描いているため、今後はイカを積極的に食べていこうと思える作品です。
+    .post
+      .post__top
+        .post__top__user
+          %img.icon(src="" alt="")/
+          = link_to "" do
+            ユーザ名
+      .post__center
+        %img.image(src="" alt="")/
+        %h5.post__center__content
+          なぜ家庭にあるのが"イカ焼き器"ではなく"たこ焼き器"なのか
+      .post__bottom
+        %p.post__bottom__title
+          『壺からの脱出』
+        %p.post__bottom__author
+          著者: 伊藤駿介
+        %p.post__bottom__content
+          この作品ではタコが人間になるまでの過程を描いているため、今後はイカを積極的に食べていこうと思える作品です。
+    .post
+      .post__top
+        .post__top__user
+          %img.icon(src="" alt="")/
+          = link_to "" do
+            ユーザ名
+      .post__center
+        %img.image(src="" alt="")/
+        %h5.post__center__content
+          なぜ家庭にあるのが"イカ焼き器"ではなく"たこ焼き器"なのか
+      .post__bottom
+        %p.post__bottom__title
+          『壺からの脱出』
+        %p.post__bottom__author
+          著者: 伊藤駿介
+        %p.post__bottom__content
+          この作品ではタコが人間になるまでの過程を描いているため、今後はイカを積極的に食べていこうと思える作品です。

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -12,7 +12,7 @@
           = link_to "" do
             コラム
         %li
-          = link_to "" do
+          = link_to posts_path do
             投稿一覧
         %li
           = link_to "" do


### PR DESCRIPTION
## What
記事投稿一覧ページの実装

## Why
記事投稿一覧ページを仮置きで作成し、投稿一覧ページのイメージを掴むため。
まずはビューのみを作成し、サーバーサイドの実装の際に、対応した記述へと変更する。