### PR TITLE
add_delete_function_to_post

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -23,6 +23,11 @@ class PostsController < ApplicationController
     post.update(post_params)
   end
 
+  def destroy
+    post = Post.find(params[:id])
+    post.destroy
+  end
+
   private
   def post_params
     params.require(:post).permit(:text, :title, :image, :author, :introduction).merge(user_id: current_user.id)

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -14,7 +14,7 @@
             %li
               = link_to '編集', edit_post_path(post), method: :get
             %li
-              = link_to '削除', "", method: :delete
+              = link_to '削除', "/tweets/#{tweet.id}", method: :delete
   .post__center
     %img.image(src="" alt="")/
     %h5.post__center__content

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -14,7 +14,7 @@
             %li
               = link_to '編集', edit_post_path(post), method: :get
             %li
-              = link_to '削除', "/tweets/#{tweet.id}", method: :delete
+              = link_to '削除', "/posts/#{post.id}", method: :delete
   .post__center
     %img.image(src="" alt="")/
     %h5.post__center__content

--- a/app/views/posts/destroy.html.haml
+++ b/app/views/posts/destroy.html.haml
@@ -1,0 +1,7 @@
+= render partial: 'shared/header'
+.created_box
+  .success_box
+    %h3
+      削除が完了しました。
+    = link_to posts_path do
+      投稿一覧へ戻る

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root "top#index"
-  resources :posts, only: [:index, :new, :create, :edit, :update]
+  resources :posts, only: [:index, :new, :create, :edit, :update, :destroy]
 end


### PR DESCRIPTION
## What
投稿記事削除機能を追加する。

## Why
投稿した記事を削除できるようにすることで、ユーザが自分自身の投稿を管理しやすくなる。
投稿&編集機能は既に実装したため、削除機能も追加することで、UXを向上させる。

## Supplement
自分自身の投稿のみ削除できるようにする。
他ユーザに投稿をいじられては迷惑極まりない。